### PR TITLE
Options migration fixes

### DIFF
--- a/src/options.css
+++ b/src/options.css
@@ -83,7 +83,6 @@ span.PhraseList__phraseCount {
   display: inline-flex;
   align-items: center;
   padding: 0.25rem 0.5rem;
-  margin-left: 0.5rem;
   border-radius: 9999px;
   font-size: 0.8rem;
 }

--- a/src/options.css
+++ b/src/options.css
@@ -79,6 +79,15 @@ span.tag.Allowlist__url {
   margin-bottom: 1rem;
 }
 
+span.PhraseList__phraseCount {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+  margin-left: 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.8rem;
+}
+
 span.Denylist__url {
   background-color: #ff3860;
   color: white;

--- a/src/options.html
+++ b/src/options.html
@@ -177,6 +177,7 @@
                 <h1 class="title">
                   <button class="PhraseList__color" style="background-color: #000000"></button>
                   <span class="PhraseList__title"> </span>
+                  <span class="tag PhraseList__phraseCount"> </span>
                 </h1>
               </div>
             </div>

--- a/src/options.js
+++ b/src/options.js
@@ -97,10 +97,14 @@ $(function () {
   function addExistingListStyles(options) {
     let highlighterStyles = `<style id="HighlighterStyles">span.PhraseList__phrase, span.Denylist__url { ${options.baseStyles} }\r\n`;
     for (let i = 0; i < options.highlighter.length; i++) {
-      if (Object.keys(options.highlighter[i]).length) {
-        // Skip deleted lists!
-        let highlighterColor = options.highlighter[i].color || 'black';
-        let textColor = options.highlighter[i].textColor || 'white';
+      // Destructuring assignment for color, textColor
+      const { color: highlighterColor = 'black', textColor = 'white' } = options.highlighter[i];
+      // Only true for non-empty lists, skipping empty lists
+      if (options.highlighter[i]) {
+        $(`#PhraseList--${i} .PhraseList__phraseCount`).css({
+          backgroundColor: highlighterColor,
+          color: textColor
+        });
         highlighterStyles += `span.PhraseList__phrase--${i} { background-color: ${highlighterColor}; color: ${textColor} }\r\n`;
       }
     }
@@ -135,6 +139,7 @@ $(function () {
       .data('index', index);
     $newListDiv.find('.PhraseList__color').css('background-color', color);
     $newListDiv.find('.PhraseList__title').text(title);
+    $newListDiv.find('.PhraseList__phraseCount').text('0 phrases');
     if (isImportPreview) {
       $('#BulkImportPreviewModal__preview').append($newListDiv);
     } else {
@@ -150,7 +155,18 @@ $(function () {
           <button class="delete is-small PhraseList__phrase__delete"></button>
         </span>`,
     );
+    updatePhraseCount($listDiv, 1); // Increments the phrase count
   }
+
+  function updatePhraseCount($listDiv, countChange) {
+    const $phraseCount = $listDiv.find('.PhraseList__phraseCount');
+    // Defaults to 0 if data-count attribute not set
+    let phraseCount = parseInt($phraseCount.data('count') || 0, 10);
+    phraseCount += countChange;
+    $phraseCount.data('count', phraseCount);
+    $phraseCount.text(`${phraseCount} phrase${phraseCount !== 1 ? 's' : ''}`);
+  }
+  
   function addPreviewPhraseElement($listDiv, phrase, color) {
     const textColor = getTextColor(color);
     $listDiv
@@ -367,6 +383,7 @@ $(function () {
           options.highlighter[listIndex].phrases.splice(phraseIndex, 1);
           chrome.storage.local.set({ highlighter: options.highlighter }, () => {
             $phrases.find($phrase).remove();
+            updatePhraseCount($list, -1); // Decrements the phrase count
           });
         });
       }

--- a/src/options.js
+++ b/src/options.js
@@ -10,7 +10,7 @@ $(function () {
     removeExistingListStyles();
 
     addExistingLists(options.highlighter);
-    addExistingListStyles(options);
+    redoAllListStyles(options);
 
     // These handlers should only be ran once.
     if (fresh) {
@@ -29,7 +29,7 @@ $(function () {
   }
 
   function removeExistingListStyles() {
-    $(`.HighlighterStyles`).remove();
+    $('#HighlighterStyles').remove();
   }
 
   function redoAllListStyles(options) {
@@ -97,10 +97,9 @@ $(function () {
   function addExistingListStyles(options) {
     let highlighterStyles = `<style id="HighlighterStyles">span.PhraseList__phrase, span.Denylist__url { ${options.baseStyles} }\r\n`;
     for (let i = 0; i < options.highlighter.length; i++) {
-      // Destructuring assignment for color, textColor
       const { color: highlighterColor = 'black', textColor = 'white' } = options.highlighter[i];
-      // Only true for non-empty lists, skipping empty lists
-      if (options.highlighter[i]) {
+      // Skip empty lists!
+      if (Object.keys(options.highlighter[i]).length) {
         $(`#PhraseList--${i} .PhraseList__phraseCount`).css({
           backgroundColor: highlighterColor,
           color: textColor
@@ -155,14 +154,22 @@ $(function () {
           <button class="delete is-small PhraseList__phrase__delete"></button>
         </span>`,
     );
-    updatePhraseCount($listDiv, 1); // Increments the phrase count
+    incrementPhraseCount($listDiv);
   }
 
-  function updatePhraseCount($listDiv, countChange) {
+  function incrementPhraseCount($listDiv) {
     const $phraseCount = $listDiv.find('.PhraseList__phraseCount');
     // Defaults to 0 if data-count attribute not set
     let phraseCount = parseInt($phraseCount.data('count') || 0, 10);
-    phraseCount += countChange;
+    phraseCount++;
+    $phraseCount.data('count', phraseCount);
+    $phraseCount.text(`${phraseCount} phrase${phraseCount !== 1 ? 's' : ''}`);
+  }
+
+  function decrementPhraseCount($listDiv) {
+    const $phraseCount = $listDiv.find('.PhraseList__phraseCount');
+    let phraseCount = parseInt($phraseCount.data('count') || 0, 10);
+    phraseCount--;
     $phraseCount.data('count', phraseCount);
     $phraseCount.text(`${phraseCount} phrase${phraseCount !== 1 ? 's' : ''}`);
   }
@@ -383,7 +390,7 @@ $(function () {
           options.highlighter[listIndex].phrases.splice(phraseIndex, 1);
           chrome.storage.local.set({ highlighter: options.highlighter }, () => {
             $phrases.find($phrase).remove();
-            updatePhraseCount($list, -1); // Decrements the phrase count
+            decrementPhraseCount($list);
           });
         });
       }

--- a/src/options.js
+++ b/src/options.js
@@ -10,7 +10,7 @@ $(function () {
     removeExistingListStyles();
 
     addExistingLists(options.highlighter);
-    redoAllListStyles(options);
+    addExistingListStyles(options);
 
     // These handlers should only be ran once.
     if (fresh) {


### PR DESCRIPTION
Use the missing option name as the key when setting to its default value.

Set the highlighter property outside the loop, after converting all the non-hex colors to hex in each list.