### PR TITLE
feat: Migrate manifest from v2 to v3

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -82,7 +82,7 @@ chrome.runtime.onInstalled.addListener((details) => {
   }
 });
 
-chrome.browserAction.onClicked.addListener((tab) => {
+chrome.action.onClicked.addListener((tab) => {
   chrome.tabs.sendMessage(tab.id, 'highlighty');
 });
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
 
   "name": "Highlighty",
   "short_name": "highlighty",
@@ -21,7 +21,7 @@
     }
   ],
 
-  "browser_action": {
+  "action": {
     "default_title": "Highlight phrases!",
     "default_icon": {
       "16": "img/16pxBlue.png",
@@ -33,9 +33,8 @@
   "options_page": "options.html",
 
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
 
-  "permissions": ["activeTab", "storage"]
+  "permissions": ["activeTab", "storage", "background"]
 }


### PR DESCRIPTION
This commit includes the necessary changes to migrate the manifest from v2 to v3. 
All deprecated and incompatible features have been updated, and the manifest now adheres to the v3 specification.

Fixes #50