### PR TITLE
Add Custom Keyboard Shortcuts

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -21,6 +21,10 @@ const defaultOptions = {
   enableCaseInsensitive: true,
   enableURLDenylist: false,
   enableURLAllowlist: false,
+  /**
+   * Keyboard shortcut string to activate highlighter.
+   * e.g. "ctrl + shift + F5"
+   */
   keyboardShortcut: 'F6',
 };
 

--- a/src/background.js
+++ b/src/background.js
@@ -78,6 +78,16 @@ chrome.runtime.onInstalled.addListener((details) => {
         }
         chrome.storage.local.set({ highlighter: currentOptions.highlighter });
       });
+
+      /**
+       * Convert legacy keyboard shortcut options to their updated equivalents.
+       */
+      if (currentOptions.keyboardShortcut === -1) {
+        currentOptions.keyboardShortcut = '';
+      } else if (currentOptions.keyboardShortcut === 117) {
+        currentOptions.keyboardShortcut = 'F6';
+      }
+      chrome.storage.local.set({ keyboardShortcut: currentOptions.keyboardShortcut });
     });
   }
 });

--- a/src/background.js
+++ b/src/background.js
@@ -21,7 +21,7 @@ const defaultOptions = {
   enableCaseInsensitive: true,
   enableURLDenylist: false,
   enableURLAllowlist: false,
-  keyboardShortcut: 117,
+  keyboardShortcut: 'F6',
 };
 
 const migratedOptionsMap = {

--- a/src/highlighty.js
+++ b/src/highlighty.js
@@ -180,32 +180,30 @@ $(function () {
   });
 
   chrome.storage.local.get((options) => {
-    const handleKeyDownWithShortcut = (event) => {
-      handleKeyDown(event, options.keyboardShortcut);
-    };
-
-    window.addEventListener('keydown', handleKeyDownWithShortcut);
+    if (options.keyboardShortcut && options.keyboardShortcut.trim() !== '') {
+      window.addEventListener('keydown', (e) => {
+        const specialKeys = {
+          ' ': 'space',
+        };
+        const pressedKeys = [];
+        if (e.ctrlKey) pressedKeys.push('ctrl');
+        if (e.shiftKey) pressedKeys.push('shift');
+        if (e.altKey) pressedKeys.push('alt');
+        if (e.metaKey) pressedKeys.push('meta');
+        let keyStr = ['Control', 'Shift', 'Alt', 'Meta,'].includes(e.key)
+          ? ''
+          : specialKeys[e.key] || e.key;
+        if (keyStr.length < 2) {
+          keyStr = keyStr.toLowerCase();
+        }
+        if (keyStr) pressedKeys.push(keyStr);
+        const pressedKeysString = pressedKeys.join(' + ').trim();
+        if (pressedKeysString === options.keyboardShortcut) {
+          processHighlights(true);
+        }
+      });
+    }
   });
-
-  function handleKeyDown(e, keyboardShortcut) {
-      const specialKeys = {
-        ' ': 'space',
-      };
-      const pressedKeys = [];
-      if (e.ctrlKey) pressedKeys.push('ctrl');
-      if (e.shiftKey) pressedKeys.push('shift');
-      if (e.altKey) pressedKeys.push('alt');
-      if (e.metaKey) pressedKeys.push('meta');
-      let  keyStr = ["Control", "Shift", "Alt", "Meta,"].includes(e.key) ? '' : specialKeys[e.key] || e.key;
-      if (keyStr.length < 2) {
-        keyStr = keyStr.toLowerCase();
-      }
-      if (keyStr) pressedKeys.push(keyStr);
-      const pressedKeysString = pressedKeys.join(' + ').trim();
-      if (pressedKeysString === keyboardShortcut) {
-        processHighlights(true);
-      }
-  }
 
   chrome.runtime.onMessage.addListener((message) => {
     if (message === 'highlighty') {

--- a/src/highlighty.js
+++ b/src/highlighty.js
@@ -180,12 +180,32 @@ $(function () {
   });
 
   chrome.storage.local.get((options) => {
-    $(window).keydown((event) => {
-      if (event.keyCode == options.keyboardShortcut) {
+    const handleKeyDownWithShortcut = (event) => {
+      handleKeyDown(event, options.keyboardShortcut);
+    };
+
+    window.addEventListener('keydown', handleKeyDownWithShortcut);
+  });
+
+  function handleKeyDown(e, keyboardShortcut) {
+      const specialKeys = {
+        ' ': 'space',
+      };
+      const pressedKeys = [];
+      if (e.ctrlKey) pressedKeys.push('ctrl');
+      if (e.shiftKey) pressedKeys.push('shift');
+      if (e.altKey) pressedKeys.push('alt');
+      if (e.metaKey) pressedKeys.push('meta');
+      let  keyStr = ["Control", "Shift", "Alt", "Meta,"].includes(e.key) ? '' : specialKeys[e.key] || e.key;
+      if (keyStr.length < 2) {
+        keyStr = keyStr.toLowerCase();
+      }
+      if (keyStr) pressedKeys.push(keyStr);
+      const pressedKeysString = pressedKeys.join(' + ').trim();
+      if (pressedKeysString === keyboardShortcut) {
         processHighlights(true);
       }
-    });
-  });
+  }
 
   chrome.runtime.onMessage.addListener((message) => {
     if (message === 'highlighty') {

--- a/src/options.css
+++ b/src/options.css
@@ -40,13 +40,7 @@
   min-width: 6ch;
 }
 
-.keyboard-helper {
-  visibility: hidden;
-  white-space: pre;
-  position: absolute;
-}
-
-#Settings__keyboardShortcut[data-recording="true"] {
+#Settings__keyboardShortcut[data-recording='true'] {
   outline-color: #bb0000;
 }
 

--- a/src/options.css
+++ b/src/options.css
@@ -35,6 +35,21 @@
                                   supported by Chrome, Opera and Firefox */
 }
 
+#Settings__keyboardShortcut {
+  text-align: center;
+  min-width: 6ch;
+}
+
+.keyboard-helper {
+  visibility: hidden;
+  white-space: pre;
+  position: absolute;
+}
+
+#Settings__keyboardShortcut[data-recording="true"] {
+  outline-color: #bb0000;
+}
+
 /* Phrase & URL lists */
 
 #PhraseList--invisible,

--- a/src/options.html
+++ b/src/options.html
@@ -151,17 +151,15 @@
           <br />
           <div class="field is-grouped">
             <div class="control">
-              <div class="select">
-                <select id="Settings__keyboardShortcut">
-                  <option value="-1">None</option>
-                  <option value="117">F6</option>
-                </select>
+              <div class="input">
+                <input type="text" id="Settings__keyboardShortcut" data-recording="false" readonly placeholder="none"></input>
+                <span id="keyboardShortcutHelper" class="keyboard-helper"></span>
               </div>
             </div>
             <div class="field-label is-normal">
-              <label for="Settings__keyboardShortcut" class="label is-pulled-left"
-                >Keyboard shortcut for extension button</label
-              >
+              <label for="Settings__keyboardShortcut" class="label is-pulled-left">
+                Keyboard shortcut for extension button
+              </label>
             </div>
           </div>
           <div class="button is-info" id="Settings__save">Save</div>

--- a/src/options.html
+++ b/src/options.html
@@ -153,7 +153,6 @@
             <div class="control">
               <div class="input">
                 <input type="text" id="Settings__keyboardShortcut" data-recording="false" readonly placeholder="none"></input>
-                <span id="keyboardShortcutHelper" class="keyboard-helper"></span>
               </div>
             </div>
             <div class="field-label is-normal">

--- a/src/options.js
+++ b/src/options.js
@@ -64,18 +64,6 @@ $(function () {
     });
   }
 
-  function checkForShortcutConflicts(shortcut) {
-    const browserShortcuts = [
-      // Add browser shortcuts you want to check for conflicts here
-      'alt + f', 'alt + e', 'F6'
-    ];
-
-    const conflicts = browserShortcuts.filter((browserShortcut) =>
-      browserShortcut.toLowerCase() === shortcut.toLowerCase()
-    );
-    return conflicts.length > 0;
-  }
-
   function setupKeyboardShortcutHandler(savedShortcut) {
     const keyboardShortcutHelper = $('#keyboardShortcutHelper')
     const keyboardShortcutInput = $('#Settings__keyboardShortcut');
@@ -119,6 +107,7 @@ $(function () {
       if (e.altKey) pressedKeys.push('alt');
       if (e.metaKey) pressedKeys.push('meta');
       let  keyStr = ["Control", "Shift", "Alt", "Meta,"].includes(e.key) ? '' : specialKeys[e.key] || e.key;
+      // Function keys remain capitalized
       if (keyStr.length < 2) {
         keyStr = keyStr.toLowerCase();
       }

--- a/src/options.js
+++ b/src/options.js
@@ -65,13 +65,16 @@ $(function () {
   }
 
   function setupKeyboardShortcutHandler(savedShortcut) {
-    const keyboardShortcutHelper = $('#keyboardShortcutHelper')
     const keyboardShortcutInput = $('#Settings__keyboardShortcut');
 
     function updateShortcutInput(shortcutString) {
       keyboardShortcutInput.val(shortcutString);
-      keyboardShortcutHelper.text(shortcutString);
-      keyboardShortcutInput.width(keyboardShortcutHelper.width());
+      keyboardShortcutInput.width((shortcutString.length + 6) * 5);
+    }
+
+    function stopRecording() {
+      document.getElementById('Settings__keyboardShortcut').setAttribute('data-recording', 'false');
+      document.removeEventListener('keydown', handleKeyDown);
     }
 
     $(document).ready(() => {
@@ -84,21 +87,20 @@ $(function () {
     });
 
     keyboardShortcutInput.on('blur', () => {
-      document.getElementById('Settings__keyboardShortcut').setAttribute('data-recording', 'false');
-      document.removeEventListener('keydown', handleKeyDown);
+      stopRecording();
     });
-  
+
     function handleKeyDown(e) {
       if (e.key === 'Enter') {
         keyboardShortcutInput.blur();
         return;
       }
       if (e.key === 'Escape') {
-        $('#Settings__keyboardShortcut').val('');
+        keyboardShortcutInput.blur();
         updateShortcutInput('');
         return;
       }
-      const specialKeys = {   
+      const specialKeys = {
         ' ': 'space',
       };
       const pressedKeys = [];
@@ -106,7 +108,9 @@ $(function () {
       if (e.shiftKey) pressedKeys.push('shift');
       if (e.altKey) pressedKeys.push('alt');
       if (e.metaKey) pressedKeys.push('meta');
-      let  keyStr = ["Control", "Shift", "Alt", "Meta,"].includes(e.key) ? '' : specialKeys[e.key] || e.key;
+      let keyStr = ['Control', 'Shift', 'Alt', 'Meta,'].includes(e.key)
+        ? ''
+        : specialKeys[e.key] || e.key;
       // Function keys remain capitalized
       if (keyStr.length < 2) {
         keyStr = keyStr.toLowerCase();
@@ -156,7 +160,7 @@ $(function () {
       if (Object.keys(options.highlighter[i]).length) {
         $(`#PhraseList--${i} .PhraseList__phraseCount`).css({
           backgroundColor: highlighterColor,
-          color: textColor
+          color: textColor,
         });
         highlighterStyles += `span.PhraseList__phrase--${i} { background-color: ${highlighterColor}; color: ${textColor} }\r\n`;
       }
@@ -227,7 +231,7 @@ $(function () {
     $phraseCount.data('count', phraseCount);
     $phraseCount.text(`${phraseCount} phrase${phraseCount !== 1 ? 's' : ''}`);
   }
-  
+
   function addPreviewPhraseElement($listDiv, phrase, color) {
     const textColor = getTextColor(color);
     $listDiv

--- a/src/options.js
+++ b/src/options.js
@@ -8,6 +8,7 @@ $(function () {
   function setupOptionsPage(options, fresh = true) {
     removeExistingLists();
     removeExistingListStyles();
+    setupKeyboardShortcutHandler(options.keyboardShortcut);
 
     addExistingLists(options.highlighter);
     addExistingListStyles(options);
@@ -61,6 +62,70 @@ $(function () {
     $('#Settings__enableAutoHighlight').on('click', function () {
       showHideAutoHighlightSettings();
     });
+  }
+
+  function checkForShortcutConflicts(shortcut) {
+    const browserShortcuts = [
+      // Add browser shortcuts you want to check for conflicts here
+      'alt + f', 'alt + e', 'F6'
+    ];
+
+    const conflicts = browserShortcuts.filter((browserShortcut) =>
+      browserShortcut.toLowerCase() === shortcut.toLowerCase()
+    );
+    return conflicts.length > 0;
+  }
+
+  function setupKeyboardShortcutHandler(savedShortcut) {
+    const keyboardShortcutHelper = $('#keyboardShortcutHelper')
+    const keyboardShortcutInput = $('#Settings__keyboardShortcut');
+
+    function updateShortcutInput(shortcutString) {
+      keyboardShortcutInput.val(shortcutString);
+      keyboardShortcutHelper.text(shortcutString);
+      keyboardShortcutInput.width(keyboardShortcutHelper.width());
+    }
+
+    $(document).ready(() => {
+      updateShortcutInput(savedShortcut);
+    });
+
+    keyboardShortcutInput.on('focus', () => {
+      document.getElementById('Settings__keyboardShortcut').setAttribute('data-recording', 'true');
+      document.addEventListener('keydown', handleKeyDown);
+    });
+
+    keyboardShortcutInput.on('blur', () => {
+      document.getElementById('Settings__keyboardShortcut').setAttribute('data-recording', 'false');
+      document.removeEventListener('keydown', handleKeyDown);
+    });
+  
+    function handleKeyDown(e) {
+      if (e.key === 'Enter') {
+        keyboardShortcutInput.blur();
+        return;
+      }
+      if (e.key === 'Escape') {
+        $('#Settings__keyboardShortcut').val('');
+        updateShortcutInput('');
+        return;
+      }
+      const specialKeys = {   
+        ' ': 'space',
+      };
+      const pressedKeys = [];
+      if (e.ctrlKey) pressedKeys.push('ctrl');
+      if (e.shiftKey) pressedKeys.push('shift');
+      if (e.altKey) pressedKeys.push('alt');
+      if (e.metaKey) pressedKeys.push('meta');
+      let  keyStr = ["Control", "Shift", "Alt", "Meta,"].includes(e.key) ? '' : specialKeys[e.key] || e.key;
+      if (keyStr.length < 2) {
+        keyStr = keyStr.toLowerCase();
+      }
+      if (keyStr) pressedKeys.push(keyStr);
+      let pressedKeysString = pressedKeys.join(' + ').trim();
+      updateShortcutInput(pressedKeysString);
+    }
   }
 
   function addExistingURLLists(options) {


### PR DESCRIPTION
Allows user to define custom keyboard shortcuts to enable the extension. 
Supports combo key shortcuts using Ctrl, Shift, Alt, and Meta keys. 
Red border color indicates shortcut sequence recording is active.
Click in to activate, click out or press escape to deactivate

Demo:

https://github.com/wustep/highlighty/assets/38960346/2c51889d-324e-4dfe-90de-80767fd0c921

Fixes #36